### PR TITLE
Internalized OTCore dependency

### DIFF
--- a/Sources/TimecodeKit/Timecode Validation.swift
+++ b/Sources/TimecodeKit/Timecode Validation.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import OTCore
+@_implementationOnly import OTCore
 
 extension Timecode {
 	


### PR DESCRIPTION
Prevented internal dependency namespace from being exposed when importing TimecodeKit.