### PR TITLE
1.0.11

### DIFF
--- a/Sources/TimecodeKit/FrameRate/FrameRate CompatibleGroup.swift
+++ b/Sources/TimecodeKit/FrameRate/FrameRate CompatibleGroup.swift
@@ -29,7 +29,6 @@ extension Timecode.FrameRate {
 		/// - 00:59:56:12 @ 29.97 fps
 		public static var table: [CompatibleGroup : [Timecode.FrameRate]] =
 			[
-				
 				.NTSC: [
 					._23_976,
 					._24_98,
@@ -61,7 +60,6 @@ extension Timecode.FrameRate {
 					._60_drop,
 					._120_drop
 				]
-				
 			]
 		
 	}

--- a/Sources/TimecodeKit/FrameRate/FrameRate CompatibleGroup.swift
+++ b/Sources/TimecodeKit/FrameRate/FrameRate CompatibleGroup.swift
@@ -77,19 +77,30 @@ extension Timecode.FrameRate {
 		
 	}
 	
-	/// Returns true if the source `FrameRate` shares a compatible grouping with the passed `timecode`.
+	/// Returns the members of the frame rate's `CompatibleGroup` categorization.
+	@inlinable public var compatibleGroupRates: [Self] {
+		
+		// Force-unwrap here will never crash because the unit tests ensure the table contains all Timecode.FrameRate cases.
+		
+		Self.CompatibleGroup.table
+			.first(where: { $0.value.contains(self) })!
+			.value
+		
+	}
+	
+	/// Returns true if the source `FrameRate` shares a compatible grouping with the passed `other` frame rate.
 	///
 	/// For example, at the same point of elapsed real time, 30 and 60 fps are compatible with each other, but 29.97 is not:
 	///
 	/// - 01:00:00:00 @ 30 fps
 	/// - 01:00:00:00 @ 60 fps
 	/// - 00:59:56:12 @ 29.97 fps
-	@inlinable public func isCompatible(with timecode: Self) -> Bool {
+	@inlinable public func isCompatible(with other: Self) -> Bool {
 		
 		Self.CompatibleGroup.table
 			.values
 			.first(where: { $0.contains(self) })?
-			.contains(timecode)
+			.contains(other)
 			?? false
 		
 	}

--- a/Sources/TimecodeKit/FrameRate/FrameRate CompatibleGroup.swift
+++ b/Sources/TimecodeKit/FrameRate/FrameRate CompatibleGroup.swift
@@ -66,6 +66,38 @@ extension Timecode.FrameRate {
 		
 	}
 	
+}
+
+extension Timecode.FrameRate.CompatibleGroup: CustomStringConvertible {
+	
+	public var description: String {
+		
+		stringValue
+		
+	}
+	
+	/// Returns human-readable group string.
+	public var stringValue: String {
+		switch self {
+		case .NTSC:
+			return "NTSC"
+			
+		case .NTSC_drop:
+			return "NTSC Drop-Frame"
+			
+		case .ATSC:
+			return "ATSC"
+			
+		case .ATSC_drop:
+			return "ATSC Drop-Frame"
+			
+		}
+	}
+	
+}
+
+extension Timecode.FrameRate {
+	
 	/// Returns the frame rate's `CompatibleGroup` categorization.
 	@inlinable public var compatibleGroup: CompatibleGroup {
 		

--- a/Sources/TimecodeKit/FrameRate/FrameRate.swift
+++ b/Sources/TimecodeKit/FrameRate/FrameRate.swift
@@ -131,3 +131,12 @@ extension Timecode.FrameRate: CaseIterable {
 	public static let allNonDrop: [Self] = allCases.filter { !$0.isDrop }
 	
 }
+
+@available(macOS 10.15, macCatalyst 13, iOS 13, *)
+extension Timecode.FrameRate: Identifiable {
+	
+	public var id: String {
+		rawValue
+	}
+	
+}

--- a/Tests/TimecodeKit-Unit-Tests/Unit Tests/FrameRate/FrameRate CompatibleGroup Tests.swift
+++ b/Tests/TimecodeKit-Unit-Tests/Unit Tests/FrameRate/FrameRate CompatibleGroup Tests.swift
@@ -29,7 +29,7 @@ class Timecode_UT_FrameRate_CompatibleGroup: XCTestCase {
 		
 	}
 	
-	func testCompatibleGroup_Basic() {
+	func testCompatibleGroup_compatibleGroup() {
 		
 		// methods basic spot-check
 		
@@ -52,6 +52,32 @@ class Timecode_UT_FrameRate_CompatibleGroup: XCTestCase {
 		XCTAssertEqual(Timecode.FrameRate._30_drop.compatibleGroup, .ATSC_drop)
 		XCTAssertEqual(Timecode.FrameRate._60_drop.compatibleGroup, .ATSC_drop)
 		XCTAssertTrue(Timecode.FrameRate._30_drop.isCompatible(with: ._60_drop))
+		
+	}
+	
+	func testCompatibleGroup_compatibleGroupRates() {
+		
+		for grouping in Timecode.FrameRate.CompatibleGroup.table {
+			
+			let otherGroupingsRates = Timecode.FrameRate.CompatibleGroup.table
+				.compactMap { $0.key != grouping.key ? $0 : nil }
+				.reduce(into: [], { $0 += ($1.value) })
+			
+			for rate in grouping.value {
+				XCTAssertEqual(
+					rate.compatibleGroupRates,
+					grouping.value
+				)
+			}
+			
+			for rate in otherGroupingsRates {
+				XCTAssertNotEqual(
+					rate.compatibleGroupRates,
+					grouping.value
+				)
+			}
+			
+		}
 		
 	}
 	

--- a/Tests/TimecodeKit-Unit-Tests/Unit Tests/FrameRate/FrameRate CompatibleGroup Tests.swift
+++ b/Tests/TimecodeKit-Unit-Tests/Unit Tests/FrameRate/FrameRate CompatibleGroup Tests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 @testable import TimecodeKit
+import OTCore
 
 class Timecode_UT_FrameRate_CompatibleGroup: XCTestCase {
 	
@@ -51,6 +52,36 @@ class Timecode_UT_FrameRate_CompatibleGroup: XCTestCase {
 		XCTAssertEqual(Timecode.FrameRate._30_drop.compatibleGroup, .ATSC_drop)
 		XCTAssertEqual(Timecode.FrameRate._60_drop.compatibleGroup, .ATSC_drop)
 		XCTAssertTrue(Timecode.FrameRate._30_drop.isCompatible(with: ._60_drop))
+		
+	}
+	
+	func testCompatibleGroup_isCompatible() {
+		
+		for grouping in Timecode.FrameRate.CompatibleGroup.table {
+			
+			let otherGroupingsRates = Timecode.FrameRate.CompatibleGroup.table
+				.compactMap { $0.key != grouping.key ? $0 : nil }
+				.reduce(into: [], { $0 += ($1.value) })
+			
+			// test against other rates in the same grouping
+			for srcRate in grouping.value {
+				for destRate in grouping.value {
+					
+					XCTAssertTrue(srcRate.isCompatible(with: destRate))
+					
+				}
+			}
+			
+			// test against rates in all the other groupings
+			for srcRate in grouping.value {
+				for destRate in otherGroupingsRates {
+					
+					XCTAssertFalse(srcRate.isCompatible(with: destRate))
+					
+				}
+			}
+			
+		}
 		
 	}
 	


### PR DESCRIPTION
- Added `Identifiable` conformance to `Timecode.FrameRate` (Combine, SwiftUI)
- Added `.compatibleGroupRates` to `Timecode.FrameRate`
- Updated unit tests