### PR TITLE
Add WASI (WebAssembly) support to SwiftTimecodeCore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,11 @@ jobs:
 
   wasm:
     name: Build (WASM)
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     env:
       TARGET_TRIPLE: wasm32-unknown-wasip1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
     env:
       TARGET_TRIPLE: wasm32-unknown-wasip1
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v1
     - uses: orchetect/setup-swift-wasm-sdk@main
       id: sdk-setup
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,11 +135,13 @@ jobs:
     name: Build (WASM)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      TARGET_TRIPLE: wasm32-unknown-wasip1
     steps:
     - uses: actions/checkout@main
     - uses: orchetect/setup-swift-wasm-sdk@main
       id: sdk-setup
     - name: Build
-      run: swift build --swift-sdk "$SDK_ID"
+      run: swift build --swift-sdk "$SDK_ID" --triple "$TARGET_TRIPLE"
       env:
         SDK_ID: ${{ steps.sdk-setup.outputs.id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,8 @@ jobs:
     - uses: actions/checkout@main
     - uses: orchetect/setup-swift-wasm-sdk@main
       id: sdk-setup
+      with:
+        target-triple: ${{ env.TARGET_TRIPLE }}
     - name: Build
       run: swift build --swift-sdk "$SDK_ID" --triple "$TARGET_TRIPLE"
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,3 +130,16 @@ jobs:
         target-triple: ${{ env.TARGET_TRIPLE }}
     - name: Build
       run: swift build --swift-sdk "$TARGET_TRIPLE" --static-swift-stdlib
+
+  wasm:
+    name: Build (WASM)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@main
+    - uses: orchetect/setup-swift-wasm-sdk@main
+      id: sdk-setup
+    - name: Build
+      run: swift build --swift-sdk "$SDK_ID"
+      env:
+        SDK_ID: ${{ steps.sdk-setup.outputs.id }}

--- a/Sources/SwiftTimecodeCore/Utilities/Outsourced/FloatingPoint and Darwin.swift
+++ b/Sources/SwiftTimecodeCore/Utilities/Outsourced/FloatingPoint and Darwin.swift
@@ -17,6 +17,8 @@ import Glibc
 import Musl
 #elseif canImport(Android)
 import Android
+#elseif canImport(WASILibc)
+import WASILibc
 #endif
 
 // MARK: - ceiling / floor
@@ -34,6 +36,8 @@ extension FloatingPoint {
         Musl.ceil(self)
         #elseif canImport(Android)
         Android.ceil(self)
+        #elseif canImport(WASILibc)
+        WASILibc.ceil(self)
         #endif
     }
 
@@ -49,6 +53,8 @@ extension FloatingPoint {
         Musl.floor(self)
         #elseif canImport(Android)
         Android.floor(self)
+        #elseif canImport(WASILibc)
+        WASILibc.floor(self)
         #endif
     }
 }
@@ -75,7 +81,8 @@ extension Float: FloatingPointPowerComputable {
     }
 }
 
-#if !(arch(arm64) || arch(arm) || os(watchOS)) // Float80 is now removed for ARM
+// Float80 is now removed for ARM, and does not exist on WebAssembly.
+#if !(arch(arm64) || arch(arm) || arch(wasm32) || os(watchOS))
 extension Float80: FloatingPointPowerComputable {
     /// Same as `powl()`
     /// (Functional convenience method)

--- a/Sources/SwiftTimecodeUI/Attributed String/NSAttributedString.swift
+++ b/Sources/SwiftTimecodeUI/Attributed String/NSAttributedString.swift
@@ -4,6 +4,8 @@
 //  © 2026 Steffan Andrews • Licensed under MIT License
 //
 
+#if canImport(AppKit) || canImport(UIKit)
+
 #if canImport(AppKit)
 import AppKit
 #elseif canImport(UIKit)
@@ -222,3 +224,5 @@ extension Timecode {
         return output
     }
 }
+
+#endif

--- a/Sources/SwiftTimecodeUI/Formatter/TextFormatter.swift
+++ b/Sources/SwiftTimecodeUI/Formatter/TextFormatter.swift
@@ -4,6 +4,8 @@
 //  © 2026 Steffan Andrews • Licensed under MIT License
 //
 
+#if canImport(Darwin)
+
 #if os(macOS)
 import AppKit
 #elseif os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
@@ -337,3 +339,5 @@ extension Timecode.TextFormatter {
         )
     }
 }
+
+#endif


### PR DESCRIPTION
`SwiftTimecodeCore` does not currently compile for `wasm32-unknown-wasip1`. Two things in `FloatingPoint and Darwin.swift` block it:

**1. No WASI branch in the libc `#if canImport` chains.** On WASI the `import` resolves to nothing, so the `ceiling` / `floor` getters compile to an empty body:

```
error: missing return in getter expected to return 'Self'
error: cannot find 'pow' in scope
error: cannot find 'powf' in scope
error: cannot find 'powl' in scope
```

**2. `Float80` is compiled on wasm32.** It does not exist on WebAssembly, but the guard around the `Float80: FloatingPointPowerComputable` conformance only excludes ARM and watchOS:

```
error: 'Float80' is unavailable: Float80 is not available on target platform.
```

This PR adds `#elseif canImport(WASILibc)` branches alongside the existing `Android` ones, and adds `arch(wasm32)` to the `Float80` exclusion — the same shape as the Linux/Android compatibility that landed in 3.1.2.

### Verification

| | |
|---|---|
| `swift build --swift-sdk swift-6.3-RELEASE_wasm --target SwiftTimecodeCore` | ✅ |
| `swift build --target SwiftTimecodeCore` (macOS, arm64) | ✅ |
| `swift test --filter SwiftTimecodeCoreTests` | ✅ 346 tests in 46 suites passed |

The change is inert on every existing platform: the new branches are only reachable when `WASILibc` is importable, and the `Float80` guard only gains an architecture that could never have compiled it anyway. `SwiftTimecodeAV` / `SwiftTimecodeUI` are unaffected (already `canImport(Darwin)`-gated at file scope).

### Context

We use `SwiftTimecodeCore` in a cross-platform Swift core that already ships to iOS, macOS and Android (via the Android Swift SDK), and are now evaluating a WebAssembly target. `SwiftTimecodeCore` was the only dependency in our graph that did not build for wasm32 — everything else, including our own sources, compiled unchanged.

### One note

This file is vendored from `orchetect/swift-extensions` ("Borrowed from swift-extensions 2.1.7"). Happy to send the same patch there instead — or as well — if you would rather it flow down from upstream rather than diverge here. Just say which you prefer.
