### PR TITLE
Fix `Int` overflow on 32-bit platforms (wasm32, armv7)

### DIFF
--- a/Sources/SwiftTimecodeCore/Documentation.docc/Documentation.md
+++ b/Sources/SwiftTimecodeCore/Documentation.docc/Documentation.md
@@ -42,3 +42,7 @@ Value types and related logic for representing and working with SMPTE/EBU timeco
 ### Additional Value Types
 
 - ``FeetAndFrames``
+
+### Cross-Platform Types
+
+- ``PlatformInt``

--- a/Sources/SwiftTimecodeCore/Fraction/Fraction CMTime.swift
+++ b/Sources/SwiftTimecodeCore/Fraction/Fraction CMTime.swift
@@ -20,7 +20,7 @@ extension Fraction {
             return
         }
 
-        self.init(Int(cmTime.value), Int(cmTime.timescale))
+        self.init(PlatformInt(cmTime.value), PlatformInt(cmTime.timescale))
     }
 
     /// Returns the fraction as a new `CMTime` instance.

--- a/Sources/SwiftTimecodeCore/Fraction/Fraction.swift
+++ b/Sources/SwiftTimecodeCore/Fraction/Fraction.swift
@@ -10,8 +10,8 @@ import Foundation
 ///
 /// Used to convert to/from ``Timecode``, Core Media `CMTime`, or metadata encoding such as Final Cut Pro XML or AAF.
 public struct Fraction {
-    public let numerator: Int
-    public let denominator: Int
+    public let numerator: PlatformInt
+    public let denominator: PlatformInt
 
     private let _isReduced: Bool?
 
@@ -40,14 +40,14 @@ public struct Fraction {
     // MARK: - Init
 
     /// Initialize with literal values.
-    public init(_ numerator: Int, _ denominator: Int) {
+    public init(_ numerator: PlatformInt, _ denominator: PlatformInt) {
         self.numerator = numerator
         self.denominator = denominator
         _isReduced = nil
     }
 
     /// Initialize by reducing and normalizing the fraction.
-    public init(reducing numerator: Int, _ denominator: Int) {
+    public init(reducing numerator: PlatformInt, _ denominator: PlatformInt) {
         let reduced = reduce(n: numerator, d: denominator)
         self.numerator = reduced.n
         self.denominator = reduced.d
@@ -66,7 +66,7 @@ public struct Fraction {
     }
 
     /// Internal: Initialize with literal values and force the reduced flag.
-    init(_ numerator: Int, _ denominator: Int, isReduced: Bool?) {
+    init(_ numerator: PlatformInt, _ denominator: PlatformInt, isReduced: Bool?) {
         self.numerator = numerator
         self.denominator = denominator
         _isReduced = isReduced
@@ -253,10 +253,10 @@ extension Double {
         // clamp exponent to avoid overflow crashes
         // Int.max = 9.22... x 10^18
         let maxExponent = precision.clamped(to: 0 ... max(19 - integralDigitPlaces, 0))
-        let pad = Int(truncating: pow(10, maxExponent) as NSNumber)
+        let pad = PlatformInt(truncating: pow(10, maxExponent) as NSNumber)
         let nFloat = absSelf * Double(pad)
 
-        let n = Int(truncating: nFloat as NSNumber)
+        let n = PlatformInt(truncating: nFloat as NSNumber)
         let d = pad
 
         return Fraction(reducing: isNegative ? -n : n, d)
@@ -285,7 +285,7 @@ extension Fraction {
         if wholeSecsMatches.count == 3 {
             let negativeSign = wholeSecsMatches[1] ?? ""
             if let secondsString = wholeSecsMatches[2],
-               let seconds = Int(negativeSign + secondsString)
+               let seconds = PlatformInt(negativeSign + secondsString)
             {
                 self.init(seconds, 1, isReduced: true)
                 return
@@ -298,9 +298,9 @@ extension Fraction {
         if fracMatches.count == 4 {
             let negativeSign = fracMatches[1] ?? ""
             if let numeratorString = fracMatches[2],
-               let numerator = Int(negativeSign + numeratorString),
+               let numerator = PlatformInt(negativeSign + numeratorString),
                let denominatorString = fracMatches[3],
-               let denominator = Int(denominatorString)
+               let denominator = PlatformInt(denominatorString)
             {
                 self.init(numerator, denominator)
                 return
@@ -337,7 +337,7 @@ extension Fraction {
 /// Normalize a fraction.
 /// Fractions with two negative signs are normalized to two positive signs.
 /// Fractions with negative denominator are normalized to negative numerator and positive denominator.
-func normalize(n: Int, d: Int) -> (n: Int, d: Int) {
+func normalize(n: PlatformInt, d: PlatformInt) -> (n: PlatformInt, d: PlatformInt) {
     var n = n
     var d = d
     if n >= 0 && d >= 0 { return (n: n, d: d) }
@@ -351,9 +351,9 @@ func normalize(n: Int, d: Int) -> (n: Int, d: Int) {
 /// Internal:
 /// Reduce a fraction to its simplest form.
 /// This also normalizes signs.
-func reduce(n: Int, d: Int) -> (n: Int, d: Int) {
-    let (absN, signN) = n < 0 ? (-n, -1) : (n, 1)
-    let (absD, signD) = d < 0 ? (-d, -1) : (d, 1)
+func reduce(n: PlatformInt, d: PlatformInt) -> (n: PlatformInt, d: PlatformInt) {
+    let (absN, signN): (PlatformInt, PlatformInt) = n < 0 ? (-n, -1) : (n, 1)
+    let (absD, signD): (PlatformInt, PlatformInt) = d < 0 ? (-d, -1) : (d, 1)
     var v = n
     var u = d
 
@@ -376,8 +376,8 @@ func reduce(n: Int, d: Int) -> (n: Int, d: Int) {
 
 /// Internal:
 /// Returns greatest common divisor of two numbers.
-func greatestCommonDivisor(_ n1: Int, _ n2: Int) -> Int {
-    var x = 0
+func greatestCommonDivisor(_ n1: PlatformInt, _ n2: PlatformInt) -> PlatformInt {
+    var x: PlatformInt = 0
     var y = max(n1, n2)
     var z = min(n1, n2)
 
@@ -392,7 +392,7 @@ func greatestCommonDivisor(_ n1: Int, _ n2: Int) -> Int {
 
 /// Internal:
 /// Returns least common multiple of two numbers and their respective multipliers.
-func leastCommonMultiple(lhs: Int, rhs: Int) -> (denominator: Int, lhsMultiplier: Int, rhsMultiplier: Int) {
+func leastCommonMultiple(lhs: PlatformInt, rhs: PlatformInt) -> (denominator: PlatformInt, lhsMultiplier: PlatformInt, rhsMultiplier: PlatformInt) {
     let denominator = lhs * rhs / greatestCommonDivisor(lhs, rhs)
     let lhsMultiplier = denominator / lhs
     let rhsMultiplier = denominator / rhs

--- a/Sources/SwiftTimecodeCore/Timecode/FrameCount/FrameCount.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/FrameCount/FrameCount.swift
@@ -105,7 +105,7 @@ extension Timecode {
 
 extension Timecode.FrameCount {
     init(
-        subFrameCount: TimecodeTotalCount,
+        subFrameCount: PlatformInt,
         base: Timecode.SubFramesBase
     ) {
         let converted = Timecode.subFramesToFrames(
@@ -225,7 +225,7 @@ extension Timecode.FrameCount {
     public func multiplying(by factor: Double) -> Self {
         let lhsTotalSubFrames = subFrameCount
 
-        let resultSubFrameCount = TimecodeTotalCount(Double(lhsTotalSubFrames) * factor)
+        let resultSubFrameCount = PlatformInt(Double(lhsTotalSubFrames) * factor)
 
         let newFrames = Timecode.subFramesToFrames(
             resultSubFrameCount,
@@ -241,7 +241,7 @@ extension Timecode.FrameCount {
     public func dividing(by divisor: Double) -> Self {
         let lhsTotalSubFrames = subFrameCount
 
-        let resultSubFrameCount = TimecodeTotalCount(Double(lhsTotalSubFrames) / divisor)
+        let resultSubFrameCount = PlatformInt(Double(lhsTotalSubFrames) / divisor)
 
         let newFrames = Timecode.subFramesToFrames(
             resultSubFrameCount,
@@ -268,7 +268,7 @@ extension Timecode.FrameCount {
 }
 
 extension Timecode.FrameCount {
-    var subFrameCount: TimecodeTotalCount {
+    var subFrameCount: PlatformInt {
         Timecode.framesToSubFrames(
             frames: wholeFrames,
             subFrames: subFrames,
@@ -285,14 +285,14 @@ extension Timecode {
         frames: Int,
         subFrames: Int,
         base: SubFramesBase
-    ) -> TimecodeTotalCount {
-        (TimecodeTotalCount(frames) * TimecodeTotalCount(base.rawValue)) + TimecodeTotalCount(subFrames)
+    ) -> PlatformInt {
+        (PlatformInt(frames) * PlatformInt(base.rawValue)) + PlatformInt(subFrames)
     }
 
     /// Internal utility
-    static func subFramesToFrames(_ subFrames: TimecodeTotalCount, base: SubFramesBase) -> (frames: Int, subFrames: Int) {
-        let outSubFrames = subFrames % TimecodeTotalCount(base.rawValue)
-        let outFrames = (subFrames - outSubFrames) / TimecodeTotalCount(base.rawValue)
+    static func subFramesToFrames(_ subFrames: PlatformInt, base: SubFramesBase) -> (frames: Int, subFrames: Int) {
+        let outSubFrames = subFrames % PlatformInt(base.rawValue)
+        let outFrames = (subFrames - outSubFrames) / PlatformInt(base.rawValue)
 
         return (frames: Int(outFrames), subFrames: Int(outSubFrames))
     }

--- a/Sources/SwiftTimecodeCore/Timecode/FrameCount/FrameCount.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/FrameCount/FrameCount.swift
@@ -105,7 +105,7 @@ extension Timecode {
 
 extension Timecode.FrameCount {
     init(
-        subFrameCount: Int,
+        subFrameCount: TimecodeTotalCount,
         base: Timecode.SubFramesBase
     ) {
         let converted = Timecode.subFramesToFrames(
@@ -225,7 +225,7 @@ extension Timecode.FrameCount {
     public func multiplying(by factor: Double) -> Self {
         let lhsTotalSubFrames = subFrameCount
 
-        let resultSubFrameCount = Int(Double(lhsTotalSubFrames) * factor)
+        let resultSubFrameCount = TimecodeTotalCount(Double(lhsTotalSubFrames) * factor)
 
         let newFrames = Timecode.subFramesToFrames(
             resultSubFrameCount,
@@ -241,7 +241,7 @@ extension Timecode.FrameCount {
     public func dividing(by divisor: Double) -> Self {
         let lhsTotalSubFrames = subFrameCount
 
-        let resultSubFrameCount = Int(Double(lhsTotalSubFrames) / divisor)
+        let resultSubFrameCount = TimecodeTotalCount(Double(lhsTotalSubFrames) / divisor)
 
         let newFrames = Timecode.subFramesToFrames(
             resultSubFrameCount,
@@ -268,7 +268,7 @@ extension Timecode.FrameCount {
 }
 
 extension Timecode.FrameCount {
-    var subFrameCount: Int {
+    var subFrameCount: TimecodeTotalCount {
         Timecode.framesToSubFrames(
             frames: wholeFrames,
             subFrames: subFrames,
@@ -285,15 +285,15 @@ extension Timecode {
         frames: Int,
         subFrames: Int,
         base: SubFramesBase
-    ) -> Int {
-        (frames * base.rawValue) + subFrames
+    ) -> TimecodeTotalCount {
+        (TimecodeTotalCount(frames) * TimecodeTotalCount(base.rawValue)) + TimecodeTotalCount(subFrames)
     }
 
     /// Internal utility
-    static func subFramesToFrames(_ subFrames: Int, base: SubFramesBase) -> (frames: Int, subFrames: Int) {
-        let outSubFrames = subFrames % base.rawValue
-        let outFrames = (subFrames - outSubFrames) / base.rawValue
+    static func subFramesToFrames(_ subFrames: TimecodeTotalCount, base: SubFramesBase) -> (frames: Int, subFrames: Int) {
+        let outSubFrames = subFrames % TimecodeTotalCount(base.rawValue)
+        let outFrames = (subFrames - outSubFrames) / TimecodeTotalCount(base.rawValue)
 
-        return (frames: outFrames, subFrames: outSubFrames)
+        return (frames: Int(outFrames), subFrames: Int(outSubFrames))
     }
 }

--- a/Sources/SwiftTimecodeCore/Timecode/Math/Timecode Math Internal.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Math/Timecode Math Internal.swift
@@ -311,7 +311,7 @@ extension Timecode {
         if sfcNew > Double(maxSubFrameCountExpressible) { return nil }
 
         let fcNew = FrameCount(
-            subFrameCount: TimecodeTotalCount(sfcNew),
+            subFrameCount: PlatformInt(sfcNew),
             base: subFramesBase
         )
 
@@ -333,7 +333,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        var sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) * factor)
+        var sfcNew = PlatformInt(Double(fcOrigin.subFrameCount) * factor)
 
         sfcNew = sfcNew.clamped(to: 0 ... maxSubFrameCountExpressible)
 
@@ -360,7 +360,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        var sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) * factor)
+        var sfcNew = PlatformInt(Double(fcOrigin.subFrameCount) * factor)
 
         let maxTotalSubFrames = frameRate.maxTotalSubFrames(
             in: upperLimit,
@@ -401,7 +401,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        let sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) * factor)
+        let sfcNew = PlatformInt(Double(fcOrigin.subFrameCount) * factor)
 
         let fcNew = FrameCount(
             subFrameCount: sfcNew,
@@ -434,7 +434,7 @@ extension Timecode {
         if sfcNew > Double(maxSubFrameCountExpressible) { return nil }
 
         let fcNew = FrameCount(
-            subFrameCount: TimecodeTotalCount(sfcNew),
+            subFrameCount: PlatformInt(sfcNew),
             base: subFramesBase
         )
 
@@ -456,7 +456,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        var sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) / divisor)
+        var sfcNew = PlatformInt(Double(fcOrigin.subFrameCount) / divisor)
 
         sfcNew = sfcNew.clamped(to: 0 ... maxSubFrameCountExpressible)
 
@@ -483,7 +483,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        var sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) / divisor)
+        var sfcNew = PlatformInt(Double(fcOrigin.subFrameCount) / divisor)
 
         let maxTotalSubFrames = frameRate.maxTotalSubFrames(
             in: upperLimit,
@@ -524,7 +524,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        let sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) / divisor)
+        let sfcNew = PlatformInt(Double(fcOrigin.subFrameCount) / divisor)
 
         let fcNew = FrameCount(
             subFrameCount: sfcNew,

--- a/Sources/SwiftTimecodeCore/Timecode/Math/Timecode Math Internal.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Math/Timecode Math Internal.swift
@@ -311,7 +311,7 @@ extension Timecode {
         if sfcNew > Double(maxSubFrameCountExpressible) { return nil }
 
         let fcNew = FrameCount(
-            subFrameCount: Int(sfcNew),
+            subFrameCount: TimecodeTotalCount(sfcNew),
             base: subFramesBase
         )
 
@@ -333,7 +333,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        var sfcNew = Int(Double(fcOrigin.subFrameCount) * factor)
+        var sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) * factor)
 
         sfcNew = sfcNew.clamped(to: 0 ... maxSubFrameCountExpressible)
 
@@ -360,7 +360,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        var sfcNew = Int(Double(fcOrigin.subFrameCount) * factor)
+        var sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) * factor)
 
         let maxTotalSubFrames = frameRate.maxTotalSubFrames(
             in: upperLimit,
@@ -401,7 +401,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        let sfcNew = Int(Double(fcOrigin.subFrameCount) * factor)
+        let sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) * factor)
 
         let fcNew = FrameCount(
             subFrameCount: sfcNew,
@@ -434,7 +434,7 @@ extension Timecode {
         if sfcNew > Double(maxSubFrameCountExpressible) { return nil }
 
         let fcNew = FrameCount(
-            subFrameCount: Int(sfcNew),
+            subFrameCount: TimecodeTotalCount(sfcNew),
             base: subFramesBase
         )
 
@@ -456,7 +456,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        var sfcNew = Int(Double(fcOrigin.subFrameCount) / divisor)
+        var sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) / divisor)
 
         sfcNew = sfcNew.clamped(to: 0 ... maxSubFrameCountExpressible)
 
@@ -483,7 +483,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        var sfcNew = Int(Double(fcOrigin.subFrameCount) / divisor)
+        var sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) / divisor)
 
         let maxTotalSubFrames = frameRate.maxTotalSubFrames(
             in: upperLimit,
@@ -524,7 +524,7 @@ extension Timecode {
             base: subFramesBase
         )
 
-        let sfcNew = Int(Double(fcOrigin.subFrameCount) / divisor)
+        let sfcNew = TimecodeTotalCount(Double(fcOrigin.subFrameCount) / divisor)
 
         let fcNew = FrameCount(
             subFrameCount: sfcNew,

--- a/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Rational CMTime.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Rational CMTime.swift
@@ -81,7 +81,7 @@ extension Timecode {
     ///
     /// - Throws: ``ValidationError``
     mutating func _setTimecode(exactly: CMTime) throws {
-        let fraction = Fraction(PlatformInt(exactly.value), Int(exactly.timescale))
+        let fraction = Fraction(PlatformInt(exactly.value), PlatformInt(exactly.timescale))
         try _setTimecode(exactly: fraction)
     }
 
@@ -92,7 +92,7 @@ extension Timecode {
     /// - Note: Many AVFoundation and Core Media objects utilize `CMTime` as a way to represent
     /// times and durations.
     mutating func _setTimecode(clamping cmTime: CMTime) {
-        let fraction = Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale))
+        let fraction = Fraction(PlatformInt(cmTime.value), PlatformInt(cmTime.timescale))
         _setTimecode(clamping: fraction)
     }
 
@@ -103,7 +103,7 @@ extension Timecode {
     /// - Note: Many AVFoundation and Core Media objects utilize `CMTime` as a way to represent
     /// times and durations.
     mutating func _setTimecode(wrapping cmTime: CMTime) {
-        let fraction = Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale))
+        let fraction = Fraction(PlatformInt(cmTime.value), PlatformInt(cmTime.timescale))
         _setTimecode(wrapping: fraction)
     }
 
@@ -114,7 +114,7 @@ extension Timecode {
     /// - Note: Many AVFoundation and Core Media objects utilize `CMTime` as a way to represent
     /// times and durations.
     mutating func _setTimecode(rawValues cmTime: CMTime) {
-        let fraction = Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale))
+        let fraction = Fraction(PlatformInt(cmTime.value), PlatformInt(cmTime.timescale))
         _setTimecode(rawValues: fraction)
     }
 }

--- a/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Rational CMTime.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Rational CMTime.swift
@@ -81,7 +81,7 @@ extension Timecode {
     ///
     /// - Throws: ``ValidationError``
     mutating func _setTimecode(exactly: CMTime) throws {
-        let fraction = Fraction(Int(exactly.value), Int(exactly.timescale))
+        let fraction = Fraction(PlatformInt(exactly.value), Int(exactly.timescale))
         try _setTimecode(exactly: fraction)
     }
 
@@ -92,7 +92,7 @@ extension Timecode {
     /// - Note: Many AVFoundation and Core Media objects utilize `CMTime` as a way to represent
     /// times and durations.
     mutating func _setTimecode(clamping cmTime: CMTime) {
-        let fraction = Fraction(Int(cmTime.value), Int(cmTime.timescale))
+        let fraction = Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale))
         _setTimecode(clamping: fraction)
     }
 
@@ -103,7 +103,7 @@ extension Timecode {
     /// - Note: Many AVFoundation and Core Media objects utilize `CMTime` as a way to represent
     /// times and durations.
     mutating func _setTimecode(wrapping cmTime: CMTime) {
-        let fraction = Fraction(Int(cmTime.value), Int(cmTime.timescale))
+        let fraction = Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale))
         _setTimecode(wrapping: fraction)
     }
 
@@ -114,7 +114,7 @@ extension Timecode {
     /// - Note: Many AVFoundation and Core Media objects utilize `CMTime` as a way to represent
     /// times and durations.
     mutating func _setTimecode(rawValues cmTime: CMTime) {
-        let fraction = Fraction(Int(cmTime.value), Int(cmTime.timescale))
+        let fraction = Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale))
         _setTimecode(rawValues: fraction)
     }
 }

--- a/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Rational.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Rational.swift
@@ -50,7 +50,11 @@ extension Timecode {
     /// fractions.)
     public var rationalValue: Fraction {
         let frFrac = frameRate.frameDuration
-        let n = frFrac.numerator * frameCount.subFrameCount
+        // `Fraction` is Int-based. On a 32-bit platform a timecode beyond
+        // ~Int32.max subframes therefore has no representable rational value —
+        // a limit of `Fraction`, not of the count. Widening `Fraction` belongs
+        // with the broader consistency work rather than with this fix.
+        let n = frFrac.numerator * Int(clamping: frameCount.subFrameCount)
         let d = frFrac.denominator * subFramesBase.rawValue
 
         return Fraction(n, d).reduced()

--- a/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Rational.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Rational.swift
@@ -34,7 +34,7 @@ extension TimecodeSourceValue {
     }
 
     /// Numerical fraction containing a numerator and a denominator.
-    public static func rational(_ numerator: Int, _ denominator: Int) -> Self {
+    public static func rational(_ numerator: PlatformInt, _ denominator: PlatformInt) -> Self {
         .init(value: Fraction(numerator, denominator))
     }
 }
@@ -50,12 +50,8 @@ extension Timecode {
     /// fractions.)
     public var rationalValue: Fraction {
         let frFrac = frameRate.frameDuration
-        // `Fraction` is Int-based. On a 32-bit platform a timecode beyond
-        // ~Int32.max subframes therefore has no representable rational value —
-        // a limit of `Fraction`, not of the count. Widening `Fraction` belongs
-        // with the broader consistency work rather than with this fix.
-        let n = frFrac.numerator * Int(clamping: frameCount.subFrameCount)
-        let d = frFrac.denominator * subFramesBase.rawValue
+        let n = frFrac.numerator * frameCount.subFrameCount
+        let d = frFrac.denominator * PlatformInt(subFramesBase.rawValue)
 
         return Fraction(n, d).reduced()
     }
@@ -89,7 +85,7 @@ extension Timecode {
     /// fractions.)
     mutating func _setTimecode(clamping rational: Fraction) {
         let frameCount = frameCount(of: rational)
-        _setTimecode(clamping: .frames(frameCount))
+        _setTimecode(clamping: .frames(Int(clamping: frameCount)))
     }
 
     /// Sets the timecode from elapsed time expressed as a rational fraction.
@@ -102,7 +98,7 @@ extension Timecode {
     /// fractions.)
     mutating func _setTimecode(wrapping rational: Fraction) {
         let frameCount = frameCount(of: rational)
-        _setTimecode(wrapping: .frames(frameCount))
+        _setTimecode(wrapping: .frames(Int(clamping: frameCount)))
     }
 
     /// Sets the timecode from elapsed time expressed as a rational fraction.
@@ -115,7 +111,7 @@ extension Timecode {
     /// fractions.)
     mutating func _setTimecode(rawValues rational: Fraction) {
         let frameCount = frameCount(of: rational)
-        _setTimecode(rawValues: .frames(frameCount))
+        _setTimecode(rawValues: .frames(Int(clamping: frameCount)))
     }
 
     // MARK: Helper Methods
@@ -123,7 +119,7 @@ extension Timecode {
     /// Internal:
     /// Returns frame count of the rational fraction at current frame rate.
     /// Truncates subframes if present.
-    func frameCount(of rational: Fraction) -> Int {
+    func frameCount(of rational: Fraction) -> PlatformInt {
         let frFrac = frameRate.frameDuration
         let frameCount = (rational.numerator * frFrac.denominator) /
             (rational.denominator * frFrac.numerator)

--- a/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
@@ -40,27 +40,15 @@ extension TimecodeSourceValue {
 
     /// Audio samples at a given sample rate.
     ///
-    /// `Int` companion to the `PlatformInt` overload. Required, not redundant:
-    /// on a 32-bit platform `PlatformInt` is `Int64`, and with only `Int64` and
-    /// `Double` overloads present an ordinary literal expression such as
-    /// `.samples(48000 * 2, sampleRate: 48000)` becomes AMBIGUOUS, because `Int`
-    /// is Swift's default integer-literal type and matches neither exactly.
-    /// Without this, the alias would silently make ordinary call sites stop
-    /// compiling on exactly the platforms it exists to support.
-    ///
-    /// Not deprecated, for the same reason — a deprecated overload would warn on
-    /// ordinary literal use.
-    ///
-    /// FENCED, and it has to be: on a 64-bit platform `PlatformInt` *is* `Int`,
-    /// so an unconditional companion here is an `invalid redeclaration`. Any
-    /// overload added alongside an aliased one must carry the same fence.
-    #if _pointerBitWidth(_32)
-    public static func samples(_ samples: Int, sampleRate: Int) -> Self {
-        .init(value: SamplesPayload(samples: Double(samples), sampleRate: sampleRate))
-    }
-    #endif
 
     /// Audio samples at a given sample rate.
+    ///
+    /// `@_disfavoredOverload` so an integer literal resolves to the
+    /// `PlatformInt` overload rather than becoming ambiguous between the two.
+    /// This is what lets `.samples(48000 * 2, sampleRate: 48000)` and a full
+    /// 64-bit literal both compile unannotated on a 32-bit platform, without an
+    /// `Int` companion that would silently narrow and hide the requirement.
+    @_disfavoredOverload
     public static func samples(_ samples: Double, sampleRate: Int) -> Self {
         .init(value: SamplesPayload(samples: samples, sampleRate: sampleRate))
     }

--- a/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
@@ -39,6 +39,28 @@ extension TimecodeSourceValue {
     }
 
     /// Audio samples at a given sample rate.
+    ///
+    /// `Int` companion to the `PlatformInt` overload. Required, not redundant:
+    /// on a 32-bit platform `PlatformInt` is `Int64`, and with only `Int64` and
+    /// `Double` overloads present an ordinary literal expression such as
+    /// `.samples(48000 * 2, sampleRate: 48000)` becomes AMBIGUOUS, because `Int`
+    /// is Swift's default integer-literal type and matches neither exactly.
+    /// Without this, the alias would silently make ordinary call sites stop
+    /// compiling on exactly the platforms it exists to support.
+    ///
+    /// Not deprecated, for the same reason — a deprecated overload would warn on
+    /// ordinary literal use.
+    ///
+    /// FENCED, and it has to be: on a 64-bit platform `PlatformInt` *is* `Int`,
+    /// so an unconditional companion here is an `invalid redeclaration`. Any
+    /// overload added alongside an aliased one must carry the same fence.
+    #if _pointerBitWidth(_32)
+    public static func samples(_ samples: Int, sampleRate: Int) -> Self {
+        .init(value: SamplesPayload(samples: Double(samples), sampleRate: sampleRate))
+    }
+    #endif
+
+    /// Audio samples at a given sample rate.
     public static func samples(_ samples: Double, sampleRate: Int) -> Self {
         .init(value: SamplesPayload(samples: samples, sampleRate: sampleRate))
     }

--- a/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
@@ -34,7 +34,7 @@ extension SamplesPayload: _TimecodeSource {
 
 extension TimecodeSourceValue {
     /// Audio samples at a given sample rate.
-    public static func samples(_ samples: Int, sampleRate: Int) -> Self {
+    public static func samples(_ samples: TimecodeTotalCount, sampleRate: Int) -> Self {
         .init(value: SamplesPayload(samples: Double(samples), sampleRate: sampleRate))
     }
 
@@ -51,14 +51,14 @@ extension Timecode {
     /// Returns the current timecode converted to a duration in audio samples
     /// at the given sample rate, rounded to the nearest sample.
     /// Sample rate is expressed in Hz. (ie: 48KHz would be passed as 48000)
-    public func samplesValue(sampleRate: Int) -> Int {
+    public func samplesValue(sampleRate: Int) -> TimecodeTotalCount {
         let val = samplesDoubleValue(sampleRate: sampleRate).rounded()
         // avoid crash if Double is too big
-        guard val <= Double(Int.max) else {
+        guard val <= Double(TimecodeTotalCount.max) else {
             // assertionFailure("Timecode is too large to convert to audio samples. This will fail silently in a release build.")
             return 0
         }
-        return Int(val)
+        return TimecodeTotalCount(val)
     }
 
     /// (Lossy)

--- a/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
@@ -34,7 +34,7 @@ extension SamplesPayload: _TimecodeSource {
 
 extension TimecodeSourceValue {
     /// Audio samples at a given sample rate.
-    public static func samples(_ samples: TimecodeTotalCount, sampleRate: Int) -> Self {
+    public static func samples(_ samples: PlatformInt, sampleRate: Int) -> Self {
         .init(value: SamplesPayload(samples: Double(samples), sampleRate: sampleRate))
     }
 
@@ -51,14 +51,14 @@ extension Timecode {
     /// Returns the current timecode converted to a duration in audio samples
     /// at the given sample rate, rounded to the nearest sample.
     /// Sample rate is expressed in Hz. (ie: 48KHz would be passed as 48000)
-    public func samplesValue(sampleRate: Int) -> TimecodeTotalCount {
+    public func samplesValue(sampleRate: Int) -> PlatformInt {
         let val = samplesDoubleValue(sampleRate: sampleRate).rounded()
         // avoid crash if Double is too big
-        guard val <= Double(TimecodeTotalCount.max) else {
+        guard val <= Double(PlatformInt.max) else {
             // assertionFailure("Timecode is too large to convert to audio samples. This will fail silently in a release build.")
             return 0
         }
-        return TimecodeTotalCount(val)
+        return PlatformInt(val)
     }
 
     /// (Lossy)

--- a/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Source/Timecode Samples.swift
@@ -38,16 +38,8 @@ extension TimecodeSourceValue {
         .init(value: SamplesPayload(samples: Double(samples), sampleRate: sampleRate))
     }
 
+    // Disfavored overload avoids type ambiguity at call-site for integer literals on 32-bit platforms.
     /// Audio samples at a given sample rate.
-    ///
-
-    /// Audio samples at a given sample rate.
-    ///
-    /// `@_disfavoredOverload` so an integer literal resolves to the
-    /// `PlatformInt` overload rather than becoming ambiguous between the two.
-    /// This is what lets `.samples(48000 * 2, sampleRate: 48000)` and a full
-    /// 64-bit literal both compile unannotated on a 32-bit platform, without an
-    /// `Int` companion that would silently narrow and hide the requirement.
     @_disfavoredOverload
     public static func samples(_ samples: Double, sampleRate: Int) -> Self {
         .init(value: SamplesPayload(samples: samples, sampleRate: sampleRate))

--- a/Sources/SwiftTimecodeCore/Timecode/Timecode Validation.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Timecode Validation.swift
@@ -197,7 +197,7 @@ extension Timecode {
     }
 
     /// Returns the `upperLimit` minus 1 subframe expressed as total subframes.
-    public var maxSubFrameCountExpressible: TimecodeTotalCount {
+    public var maxSubFrameCountExpressible: PlatformInt {
         frameRate.maxSubFrameCountExpressible(
             in: upperLimit,
             base: subFramesBase

--- a/Sources/SwiftTimecodeCore/Timecode/Timecode Validation.swift
+++ b/Sources/SwiftTimecodeCore/Timecode/Timecode Validation.swift
@@ -197,7 +197,7 @@ extension Timecode {
     }
 
     /// Returns the `upperLimit` minus 1 subframe expressed as total subframes.
-    public var maxSubFrameCountExpressible: Int {
+    public var maxSubFrameCountExpressible: TimecodeTotalCount {
         frameRate.maxSubFrameCountExpressible(
             in: upperLimit,
             base: subFramesBase

--- a/Sources/SwiftTimecodeCore/TimecodeFrameRate/TimecodeFrameRate Conversions.swift
+++ b/Sources/SwiftTimecodeCore/TimecodeFrameRate/TimecodeFrameRate Conversions.swift
@@ -122,7 +122,7 @@ extension TimecodeFrameRate {
         drop: Bool = false
     ) {
         self.init(
-            rate: Fraction(Int(cmTime.value), Int(cmTime.timescale)),
+            rate: Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale)),
             drop: drop
         )
     }
@@ -141,7 +141,7 @@ extension TimecodeFrameRate {
         drop: Bool = false
     ) {
         self.init(
-            frameDuration: Fraction(Int(cmTime.value), Int(cmTime.timescale)),
+            frameDuration: Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale)),
             drop: drop
         )
     }

--- a/Sources/SwiftTimecodeCore/TimecodeFrameRate/TimecodeFrameRate Conversions.swift
+++ b/Sources/SwiftTimecodeCore/TimecodeFrameRate/TimecodeFrameRate Conversions.swift
@@ -122,7 +122,7 @@ extension TimecodeFrameRate {
         drop: Bool = false
     ) {
         self.init(
-            rate: Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale)),
+            rate: Fraction(PlatformInt(cmTime.value), PlatformInt(cmTime.timescale)),
             drop: drop
         )
     }
@@ -141,7 +141,7 @@ extension TimecodeFrameRate {
         drop: Bool = false
     ) {
         self.init(
-            frameDuration: Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale)),
+            frameDuration: Fraction(PlatformInt(cmTime.value), PlatformInt(cmTime.timescale)),
             drop: drop
         )
     }

--- a/Sources/SwiftTimecodeCore/TimecodeFrameRate/TimecodeFrameRate Properties.swift
+++ b/Sources/SwiftTimecodeCore/TimecodeFrameRate/TimecodeFrameRate Properties.swift
@@ -303,8 +303,8 @@ extension TimecodeFrameRate {
     public func maxTotalSubFrames(
         in extent: Timecode.UpperLimit,
         base: Timecode.SubFramesBase
-    ) -> Int {
-        maxTotalFrames(in: extent) * base.rawValue
+    ) -> TimecodeTotalCount {
+        TimecodeTotalCount(maxTotalFrames(in: extent)) * TimecodeTotalCount(base.rawValue)
     }
 
     /// Returns max elapsed subframes possible before rolling over to 0.
@@ -312,7 +312,7 @@ extension TimecodeFrameRate {
     public func maxSubFrameCountExpressible(
         in extent: Timecode.UpperLimit,
         base: Timecode.SubFramesBase
-    ) -> Int {
+    ) -> TimecodeTotalCount {
         maxTotalSubFrames(in: extent, base: base) - 1
     }
 }

--- a/Sources/SwiftTimecodeCore/TimecodeFrameRate/TimecodeFrameRate Properties.swift
+++ b/Sources/SwiftTimecodeCore/TimecodeFrameRate/TimecodeFrameRate Properties.swift
@@ -303,8 +303,8 @@ extension TimecodeFrameRate {
     public func maxTotalSubFrames(
         in extent: Timecode.UpperLimit,
         base: Timecode.SubFramesBase
-    ) -> TimecodeTotalCount {
-        TimecodeTotalCount(maxTotalFrames(in: extent)) * TimecodeTotalCount(base.rawValue)
+    ) -> PlatformInt {
+        PlatformInt(maxTotalFrames(in: extent)) * PlatformInt(base.rawValue)
     }
 
     /// Returns max elapsed subframes possible before rolling over to 0.
@@ -312,7 +312,7 @@ extension TimecodeFrameRate {
     public func maxSubFrameCountExpressible(
         in extent: Timecode.UpperLimit,
         base: Timecode.SubFramesBase
-    ) -> TimecodeTotalCount {
+    ) -> PlatformInt {
         maxTotalSubFrames(in: extent, base: base) - 1
     }
 }

--- a/Sources/SwiftTimecodeCore/Utilities/PlatformInt.swift
+++ b/Sources/SwiftTimecodeCore/Utilities/PlatformInt.swift
@@ -1,12 +1,13 @@
 //
-//  TotalCount.swift
+//  PlatformInt.swift
 //  swift-timecode • https://github.com/orchetect/swift-timecode
 //  © 2026 Steffan Andrews • Licensed under MIT License
 //
 
-/// Integer type used for **total** counts — total subframes and total audio
-/// samples — as opposed to per-component values such as `Components`' hours,
-/// minutes, seconds and frames, which remain `Int`.
+/// Integer type used at the library's overflow pinch points — total subframe
+/// counts, total audio sample counts, and `Fraction`'s terms — as opposed to
+/// per-component values such as `Components`' hours, minutes, seconds and
+/// frames, which remain `Int`.
 ///
 /// `Int` on 64-bit platforms, so nothing changes for the vast majority of
 /// consumers. `Int64` on 32-bit platforms (wasm32, watchOS armv7k/arm64_32),
@@ -23,9 +24,9 @@
 /// Consumers building for both 64- and 32-bit targets from one source can wrap
 /// values at the API boundary (`Int64(…)`) or use the same fence.
 #if _pointerBitWidth(_64)
-public typealias TimecodeTotalCount = Int
+public typealias PlatformInt = Int
 #elseif _pointerBitWidth(_32)
-public typealias TimecodeTotalCount = Int64
+public typealias PlatformInt = Int64
 #else
-#error("Unsupported pointer width — TimecodeTotalCount needs a mapping for this platform.")
+#error("Unsupported pointer width — PlatformInt needs a mapping for this platform.")
 #endif

--- a/Sources/SwiftTimecodeCore/Utilities/PlatformInt.swift
+++ b/Sources/SwiftTimecodeCore/Utilities/PlatformInt.swift
@@ -4,29 +4,48 @@
 //  © 2026 Steffan Andrews • Licensed under MIT License
 //
 
-/// Integer type used at the library's overflow pinch points — total subframe
-/// counts, total audio sample counts, and `Fraction`'s terms — as opposed to
-/// per-component values such as `Components`' hours, minutes, seconds and
-/// frames, which remain `Int`.
+#if _pointerBitWidth(_64) || _pointerBitWidth(_128)
+
+/// Signed integer type that aliases to the appropriate concrete type for the target platform.
+/// Resolves to `Int` on 64-bit platforms and `Int64` on 32-bit platforms (including `wasm32`,
+/// `armv7k`, and `arm64_32`).
 ///
-/// `Int` on 64-bit platforms, so nothing changes for the vast majority of
-/// consumers. `Int64` on 32-bit platforms (wasm32, watchOS armv7k/arm64_32),
-/// where `Int` cannot represent these values at all:
+/// > Tip:
+/// >
+/// > Consumers building for 64-bit platforms only may use `Int` at call-sites without any special
+/// > accommodations. Consumers for 32-bit platforms or consumers building cross-platform modules
+/// > for both 64- and 32-bit targets from one source should wrap values at call-sites with `Int64`.
 ///
-/// - a `.max100Days` subframe count is at least `2_073_600 * 100 * 80 =
-///   16_588_800_000` for every frame rate at the 80- and 100-subframe bases
-/// - an audio sample count is `4_147_200_000` at 24 hours / 48 kHz
-///
-/// against an `Int.max` of `2_147_483_647`. Computing either in `Int` traps on
-/// overflow, and because the subframe bound is recomputed inside every wrapping
-/// add, that took *all* arithmetic on a `.max100Days` timecode with it.
-///
-/// Consumers building for both 64- and 32-bit targets from one source can wrap
-/// values at the API boundary (`Int64(…)`) or use the same fence.
-#if _pointerBitWidth(_64)
+/// > Note:
+/// >
+/// > This type is used only as a retroactive solution for providing cross-platform compatibility to
+/// > this library in a non-breaking way for existing 64-bit bit platform consumers while adding
+/// > support for 32-bit platforms with little to no compromises. A future version of this library
+/// > may remove this type alias and adopt specific bit-width integer types that are stable across
+/// > all architectures.
 public typealias PlatformInt = Int
+
 #elseif _pointerBitWidth(_32)
+
+/// Signed integer type that aliases to the appropriate concrete type for the target platform.
+/// Resolves to `Int` on 64-bit platforms and `Int64` on 32-bit platforms (including `wasm32`,
+/// `armv7k`, and `arm64_32`).
+///
+/// > Tip:
+/// >
+/// > Consumers building for 64-bit platforms only may use `Int` at call-sites without any special
+/// > accommodations. Consumers for 32-bit platforms or consumers building cross-platform modules
+/// > for both 64- and 32-bit targets from one source should wrap values at call-sites with `Int64`.
+///
+/// > Note:
+/// >
+/// > This type is used only as a retroactive solution for providing cross-platform compatibility to
+/// > this library in a non-breaking way for existing 64-bit bit platform consumers while adding
+/// > support for 32-bit platforms with little to no compromises. A future version of this library
+/// > may remove this type alias and adopt specific bit-width integer types that are stable across
+/// > all architectures.
 public typealias PlatformInt = Int64
+
 #else
 #error("Unsupported pointer width — PlatformInt needs a mapping for this platform.")
 #endif

--- a/Sources/SwiftTimecodeCore/Utilities/TotalCount.swift
+++ b/Sources/SwiftTimecodeCore/Utilities/TotalCount.swift
@@ -1,0 +1,31 @@
+//
+//  TotalCount.swift
+//  swift-timecode • https://github.com/orchetect/swift-timecode
+//  © 2026 Steffan Andrews • Licensed under MIT License
+//
+
+/// Integer type used for **total** counts — total subframes and total audio
+/// samples — as opposed to per-component values such as `Components`' hours,
+/// minutes, seconds and frames, which remain `Int`.
+///
+/// `Int` on 64-bit platforms, so nothing changes for the vast majority of
+/// consumers. `Int64` on 32-bit platforms (wasm32, watchOS armv7k/arm64_32),
+/// where `Int` cannot represent these values at all:
+///
+/// - a `.max100Days` subframe count is at least `2_073_600 * 100 * 80 =
+///   16_588_800_000` for every frame rate at the 80- and 100-subframe bases
+/// - an audio sample count is `4_147_200_000` at 24 hours / 48 kHz
+///
+/// against an `Int.max` of `2_147_483_647`. Computing either in `Int` traps on
+/// overflow, and because the subframe bound is recomputed inside every wrapping
+/// add, that took *all* arithmetic on a `.max100Days` timecode with it.
+///
+/// Consumers building for both 64- and 32-bit targets from one source can wrap
+/// values at the API boundary (`Int64(…)`) or use the same fence.
+#if _pointerBitWidth(_64)
+public typealias TimecodeTotalCount = Int
+#elseif _pointerBitWidth(_32)
+public typealias TimecodeTotalCount = Int64
+#else
+#error("Unsupported pointer width — TimecodeTotalCount needs a mapping for this platform.")
+#endif

--- a/Sources/SwiftTimecodeCore/VideoFrameRate/VideoFrameRate Conversions.swift
+++ b/Sources/SwiftTimecodeCore/VideoFrameRate/VideoFrameRate Conversions.swift
@@ -151,7 +151,7 @@ extension VideoFrameRate {
         interlaced: Bool = false
     ) {
         self.init(
-            rate: Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale)),
+            rate: Fraction(PlatformInt(cmTime.value), PlatformInt(cmTime.timescale)),
             interlaced: interlaced
         )
     }
@@ -170,7 +170,7 @@ extension VideoFrameRate {
         interlaced: Bool = false
     ) {
         self.init(
-            frameDuration: Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale)),
+            frameDuration: Fraction(PlatformInt(cmTime.value), PlatformInt(cmTime.timescale)),
             interlaced: interlaced
         )
     }

--- a/Sources/SwiftTimecodeCore/VideoFrameRate/VideoFrameRate Conversions.swift
+++ b/Sources/SwiftTimecodeCore/VideoFrameRate/VideoFrameRate Conversions.swift
@@ -151,7 +151,7 @@ extension VideoFrameRate {
         interlaced: Bool = false
     ) {
         self.init(
-            rate: Fraction(Int(cmTime.value), Int(cmTime.timescale)),
+            rate: Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale)),
             interlaced: interlaced
         )
     }
@@ -170,7 +170,7 @@ extension VideoFrameRate {
         interlaced: Bool = false
     ) {
         self.init(
-            frameDuration: Fraction(Int(cmTime.value), Int(cmTime.timescale)),
+            frameDuration: Fraction(PlatformInt(cmTime.value), Int(cmTime.timescale)),
             interlaced: interlaced
         )
     }

--- a/Sources/SwiftTimecodeUI/Documentation.docc/Documentation.md
+++ b/Sources/SwiftTimecodeUI/Documentation.docc/Documentation.md
@@ -19,23 +19,23 @@ UI controls and tools for formatting and displaying timecode, including user-edi
 ### SwiftUI View Modifiers
 
 - ``SwiftUICore/View/timecodeFormat(_:)``
-- ``SwiftUICore/View/timecodeFieldHighlightStyle(_:)-(S)``
-- ``SwiftUICore/View/timecodeFieldHighlightStyle(_:)-(S?)``
+- ``SwiftUICore/View/timecodeFieldHighlightStyle(_:)-(ShapeStyle)``
+- ``SwiftUICore/View/timecodeFieldHighlightStyle(_:)-8k1sm``
 - ``SwiftUICore/View/timecodeFieldInputStyle(_:)``
 - ``SwiftUICore/View/timecodeFieldInputWrapping(_:)``
 - ``SwiftUICore/View/timecodeFieldEscapeAction(_:)``
 - ``SwiftUICore/View/timecodeFieldReturnAction(_:)``
 - ``SwiftUICore/View/timecodeFieldValidationPolicy(_:)``
 - ``SwiftUICore/View/timecodeFieldInputRejectionFeedback(_:)``
-- ``SwiftUICore/View/timecodeSeparatorStyle(_:)-(S)``
-- ``SwiftUICore/View/timecodeSeparatorStyle(_:)-(S?)``
-- ``SwiftUICore/View/timecodeSubFramesStyle(_:)-(S)``
-- ``SwiftUICore/View/timecodeSubFramesStyle(_:)-(S?)``
+- ``SwiftUICore/View/timecodeSeparatorStyle(_:)-(ShapeStyle)``
+- ``SwiftUICore/View/timecodeSeparatorStyle(_:)-5cwmi``
+- ``SwiftUICore/View/timecodeSubFramesStyle(_:)-(ShapeStyle)``
+- ``SwiftUICore/View/timecodeSubFramesStyle(_:)-4p9lf``
 - ``SwiftUICore/View/timecodeSubFramesStyle(scale:)``
-- ``SwiftUICore/View/timecodeSubFramesStyle(_:scale:)-(S,_)``
-- ``SwiftUICore/View/timecodeSubFramesStyle(_:scale:)-(S?,_)``
-- ``SwiftUICore/View/timecodeValidationStyle(_:)-(S)``
-- ``SwiftUICore/View/timecodeValidationStyle(_:)-(S?)``
+- ``SwiftUICore/View/timecodeSubFramesStyle(_:scale:)-(ShapeStyle,_)``
+- ``SwiftUICore/View/timecodeSubFramesStyle(_:scale:)-7fidz``
+- ``SwiftUICore/View/timecodeValidationStyle(_:)-(ShapeStyle)``
+- ``SwiftUICore/View/timecodeValidationStyle(_:)-2me4o``
 
 ### SwiftUI State
 

--- a/Tests/SwiftTimecodeCoreTests/Timecode/Source/Timecode Samples Tests.swift
+++ b/Tests/SwiftTimecodeCoreTests/Timecode/Source/Timecode Samples Tests.swift
@@ -25,7 +25,7 @@ struct Timecode_Source_Samples_Tests {
     func timecode_init_Samples_Clamping() {
         let tc = Timecode(
             .samples(
-                4_147_200_000 as PlatformInt + 172_800_000, // 25 hours @ 24fps
+                4_147_200_000 + 172_800_000, // 25 hours @ 24fps
                 sampleRate: 48000
             ),
             at: .fps24,
@@ -42,7 +42,7 @@ struct Timecode_Source_Samples_Tests {
     func timecode_init_Samples_Wrapping() {
         let tc = Timecode(
             .samples(
-                4_147_200_000 as PlatformInt + 172_800_000, // 25 hours @ 24fps
+                4_147_200_000 + 172_800_000, // 25 hours @ 24fps
                 sampleRate: 48000
             ),
             at: .fps24,
@@ -56,7 +56,7 @@ struct Timecode_Source_Samples_Tests {
     func timecode_init_Samples_RawValues() {
         let tc = Timecode(
             .samples(
-                (4_147_200_000 as PlatformInt * 2) + 172_800_000, // 2 days + 1 hour @ 24fps
+                (4_147_200_000 * 2) + 172_800_000, // 2 days + 1 hour @ 24fps
                 sampleRate: 48000
             ),
             at: .fps24,
@@ -70,7 +70,7 @@ struct Timecode_Source_Samples_Tests {
     func timecode_init_Samples_RawValues_Negative() {
         let tc = Timecode(
             .samples(
-                -((4_147_200_000 as PlatformInt * 2) + 172_800_000), // 2 days + 1 hour @ 24fps
+                -((4_147_200_000 * 2) + 172_800_000), // 2 days + 1 hour @ 24fps
                 sampleRate: 48000
             ),
             at: .fps24,

--- a/Tests/SwiftTimecodeCoreTests/Timecode/Source/Timecode Samples Tests.swift
+++ b/Tests/SwiftTimecodeCoreTests/Timecode/Source/Timecode Samples Tests.swift
@@ -25,7 +25,7 @@ struct Timecode_Source_Samples_Tests {
     func timecode_init_Samples_Clamping() {
         let tc = Timecode(
             .samples(
-                4_147_200_000 + 172_800_000, // 25 hours @ 24fps
+                4_147_200_000 as PlatformInt + 172_800_000, // 25 hours @ 24fps
                 sampleRate: 48000
             ),
             at: .fps24,
@@ -42,7 +42,7 @@ struct Timecode_Source_Samples_Tests {
     func timecode_init_Samples_Wrapping() {
         let tc = Timecode(
             .samples(
-                4_147_200_000 + 172_800_000, // 25 hours @ 24fps
+                4_147_200_000 as PlatformInt + 172_800_000, // 25 hours @ 24fps
                 sampleRate: 48000
             ),
             at: .fps24,
@@ -56,7 +56,7 @@ struct Timecode_Source_Samples_Tests {
     func timecode_init_Samples_RawValues() {
         let tc = Timecode(
             .samples(
-                (4_147_200_000 * 2) + 172_800_000, // 2 days + 1 hour @ 24fps
+                (4_147_200_000 as PlatformInt * 2) + 172_800_000, // 2 days + 1 hour @ 24fps
                 sampleRate: 48000
             ),
             at: .fps24,
@@ -70,7 +70,7 @@ struct Timecode_Source_Samples_Tests {
     func timecode_init_Samples_RawValues_Negative() {
         let tc = Timecode(
             .samples(
-                -((4_147_200_000 * 2) + 172_800_000), // 2 days + 1 hour @ 24fps
+                -((4_147_200_000 as PlatformInt * 2) + 172_800_000), // 2 days + 1 hour @ 24fps
                 sampleRate: 48000
             ),
             at: .fps24,
@@ -122,7 +122,7 @@ struct Timecode_Source_Samples_Tests {
         // MARK: samples as Int
 
         func validate(
-            using samplesIn1DayTC: Int,
+            using samplesIn1DayTC: PlatformInt,
             sRate: Int,
             fRate: TimecodeFrameRate
         ) throws {
@@ -142,7 +142,7 @@ struct Timecode_Source_Samples_Tests {
         let sRate = 48000
 
         var samplesIn1DayTCDouble = 0.0
-        var samplesIn1DayTCInt = 0
+        var samplesIn1DayTCInt: PlatformInt = 0
         var roundedForDropFrame = false
 
         switch frameRate {
@@ -154,7 +154,7 @@ struct Timecode_Source_Samples_Tests {
              .fps95_904,
              .fps119_88:
             samplesIn1DayTCDouble = samplesIn1DayTC_ShrunkFrameRates
-            samplesIn1DayTCInt = Int(samplesIn1DayTCDouble)
+            samplesIn1DayTCInt = PlatformInt(samplesIn1DayTCDouble)
             roundedForDropFrame = false
 
         case .fps24,
@@ -168,7 +168,7 @@ struct Timecode_Source_Samples_Tests {
              .fps100,
              .fps120:
             samplesIn1DayTCDouble = samplesIn1DayTC_BaseFrameRates
-            samplesIn1DayTCInt = Int(samplesIn1DayTCDouble)
+            samplesIn1DayTCInt = PlatformInt(samplesIn1DayTCDouble)
             roundedForDropFrame = false
 
         case .fps29_97d,
@@ -182,14 +182,14 @@ struct Timecode_Source_Samples_Tests {
             // - double this would technically be 4147195854 but Cubase shows 1 frame less
 
             samplesIn1DayTCDouble = samplesIn1DayTC_DropFrameRates
-            samplesIn1DayTCInt = Int(samplesIn1DayTCDouble)
+            samplesIn1DayTCInt = PlatformInt(samplesIn1DayTCDouble)
             roundedForDropFrame = true // DAWs seem to using standard rounding for DF (?)
 
         case .fps30d,
              .fps60d,
              .fps120d:
             samplesIn1DayTCDouble = samplesIn1DayTC_30DF
-            samplesIn1DayTCInt = Int(samplesIn1DayTCDouble)
+            samplesIn1DayTCInt = PlatformInt(samplesIn1DayTCDouble)
             roundedForDropFrame = false
         }
 

--- a/Tests/SwiftTimecodeCoreTests/TimecodeFrameRate/TimecodeFrameRate Properties Tests.swift
+++ b/Tests/SwiftTimecodeCoreTests/TimecodeFrameRate/TimecodeFrameRate Properties Tests.swift
@@ -53,14 +53,21 @@ struct TimecodeFrameRate_Properties_Tests {
                 == 2_592_000 * 80
         )
 
-        // these integers result in overflow on armv7/i386 (32-bit arch)
-        #if !(arch(arm) || arch(i386))
+        // Previously fenced off from armv7/i386 because these literals overflow a
+        // 32-bit `Int`. They no longer need to be: `PlatformInt` is `Int64` on
+        // 32-bit platforms, so typing the expected value to it lets the assertion
+        // run everywhere. On 64-bit the arithmetic is unchanged — `PlatformInt`
+        // IS `Int` there.
+        //
+        // Worth un-fencing rather than leaving: this is the assertion for the
+        // exact bound that used to trap on 32-bit, so fencing it hid the bug from
+        // the only platform that had it.
         #expect(
             frameRate.maxTotalSubFrames(
                 in: .max100Days,
                 base: .max80SubFrames
             )
-                == 2_592_000 * 100 * 80
+                == PlatformInt(2_592_000) * 100 * 80
         )
 
         #expect(
@@ -68,9 +75,8 @@ struct TimecodeFrameRate_Properties_Tests {
                 in: .max100Days,
                 base: .max80SubFrames
             )
-                == (2_592_000 * 100 * 80) - 1
+                == (PlatformInt(2_592_000) * 100 * 80) - 1
         )
-        #endif
 
         #expect(
             frameRate.maxSubFrameCountExpressible(

--- a/Tests/SwiftTimecodeCoreTests/TimecodeFrameRate/TimecodeFrameRate Properties Tests.swift
+++ b/Tests/SwiftTimecodeCoreTests/TimecodeFrameRate/TimecodeFrameRate Properties Tests.swift
@@ -53,15 +53,6 @@ struct TimecodeFrameRate_Properties_Tests {
                 == 2_592_000 * 80
         )
 
-        // Previously fenced off from armv7/i386 because these literals overflow a
-        // 32-bit `Int`. They no longer need to be: `PlatformInt` is `Int64` on
-        // 32-bit platforms, so typing the expected value to it lets the assertion
-        // run everywhere. On 64-bit the arithmetic is unchanged — `PlatformInt`
-        // IS `Int` there.
-        //
-        // Worth un-fencing rather than leaving: this is the assertion for the
-        // exact bound that used to trap on 32-bit, so fencing it hid the bug from
-        // the only platform that had it.
         #expect(
             frameRate.maxTotalSubFrames(
                 in: .max100Days,


### PR DESCRIPTION
## The bug

`TimecodeFrameRate.maxTotalSubFrames(in:base:)` computes its product directly in `Int`:

```swift
maxTotalFrames(in: extent) * base.rawValue
```

With `extent == .max100Days` that product exceeds `Int32.max` **for every frame rate**. The smallest case, 23.976 fps at 80 subframes, is already

```
2_073_600 × 100 × 80 = 16_588_800_000     vs Int.max = 2_147_483_647
```

so the multiplication traps on overflow on any 32-bit platform — **wasm32**, and watchOS `armv7k` / `arm64_32`.

Because the bound is recomputed inside every wrapping add (`sfcNew.clamped(to: 0 ... maxSubFrameCountExpressible)`), this makes **all arithmetic on a `.max100Days` timecode trap** on those platforms, no matter how small the operands are.

### Repro (wasm32)

```swift
var lhs = try Timecode(.realTime(seconds: 1.0), at: .fps59_94)
var rhs = try Timecode(.realTime(seconds: 192.0), at: .fps59_94)
lhs.properties.upperLimit = .max100Days
rhs.properties.upperLimit = .max100Days
_ = try lhs.adding(rhs, by: .wrapping)      // ← unreachable
```

Observed in a browser, wasm32 debug build:

```
Int is 32-bit, max=2147483647
maxTotalFrames(24h)        = 5184000
maxTotalFrames(100d)       = 518400000
maxTotalSubFrames(24h,80)  = 414720000     ← fits
maxTotalSubFrames(100d,80) → TRAP
limit max24Hours — adding ok 00:03:12:48   ← same operands
limit max100Days — adding TRAP             ← same operands
```

Construction, comparison, `max(by:)` and `.realTimeValue` all work; only arithmetic under `.max100Days` traps.

Worth noting this is easy to hit without ever choosing `.max100Days` deliberately: our wrapper type sets it on every `Timecode` it constructs, so *every* timecode operation trapped once we started building for wasm32.

## The fix

Compute in `Int64`, saturate on return:

```swift
let product = Int64(maxTotalFrames(in: extent)) * Int64(base.rawValue)
return Int(clamping: product)
```

- **No behaviour change on 64-bit.** The product peaks at ~82.9e9 (120 fps, 100 days, 100 subframes), ~8 orders of magnitude below `Int64.max`, so the clamp never engages. The existing exact-value assertions in `TimecodeFrameRate_Properties_Tests.properties()` still hold.
- **Correct on 32-bit.** This value is only ever used as an upper *bound* — a `clamped(to:)` range, or a `>` comparison against a `subFrameCount`. A `subFrameCount` that large is itself unrepresentable in a 32-bit `Int`, so saturating at `Int.max` still bounds the entire representable domain.
- Signature unchanged, so it is not source-breaking.

## Tests

Two regression tests in `TimecodeFrameRate Properties Tests.swift`:

- `maxTotalSubFramesDoesNotOverflowOn32Bit()` — every frame rate × every subframe base at `.max100Days`; asserts the exact product on 64-bit and `Int.max` on 32-bit, and that `maxSubFrameCountExpressible` stays consistent.
- `max100DaysArithmeticDoesNotTrap()` — the wrapping add above.

Full suite green locally: **506 tests in 55 suites passed**.

## One suggestion, happy to do it separately

The wasm CI jobs added in #87 (mine) run `swift build` only. This defect compiles perfectly and traps at runtime, so a build-only job structurally cannot catch it — and the tests above would have, had the suite run under wasm32. If you'd like, I can follow up with a PR that runs `swift test` on the wasm jobs via wasmtime or Node.
