### PR TITLE
CI: require swift-testing-extensions 0.3.1 for WASM (groundwork for running tests)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // used only for Dev tests, not part of regular unit tests
         .package(url: "https://github.com/apple/swift-numerics", from: "1.1.1"),
-        .package(url: "https://github.com/orchetect/swift-testing-extensions", from: "0.3.0")
+        .package(url: "https://github.com/orchetect/swift-testing-extensions", from: "0.3.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Groundwork for running `swift test` on the WASM jobs rather than only `swift build`. **Not green yet** — but the remaining blocker is no longer tooling, and is described below.

*(Rewritten: this PR originally removed `TestingExtensions` from `SwiftTimecodeCoreTests`. With 0.3.1 that is unnecessary, so the removal is gone and this is now a one-line version bump.)*

## The two tooling blockers, both solved

**1. `SWCompression` — fixed by 0.3.1.** In 0.3.0, `Algorithm+DEFLATE.swift` imports it from the `#if canImport(Darwin)` / `#else` branch, so it fires on every non-Darwin platform including WASI. 0.3.1 narrows it to `#if os(Linux)`, which is correct: on `wasm32-unknown-wasip1`, `os(WASI)` is true and `os(Linux)` is false (probed directly). This PR requires 0.3.1 so resolution is explicit rather than depending on what a consumer's `Package.resolved` happens to hold.

**2. The macro errors — your prebuilds hunch was exactly right.** The SwiftPM CLI equivalent of `-IDEPackageEnablePrebuilts=NO` is `--disable-experimental-prebuilts`:

```
swift build --swift-sdk swift-6.3-RELEASE_wasm --build-tests --disable-experimental-prebuilts
```

With it, both `@Test` → *"global variable must be a compile-time constant to use @section attribute"* and `@Suite` → *"'@const' value should be initialized with a compile-time value"* disappear.

## What is left: 8 sites, one file, and it is an API question

With 0.3.1 + that flag, the entire suite compiles for wasm32 except **8 errors, all in `Tests/SwiftTimecodeCoreTests/Timecode/Source/Timecode Samples Tests.swift`** — 4 integer literals and 4 `Double`→`Int` conversions that overflow.

These are not test bugs. The API is:

```swift
public func samplesValue(sampleRate: Int) -> Int
```

and the tests use values like `4_147_200_000` — 24 hours at 48 kHz. On a 32-bit platform that is simply unrepresentable, so **audio sample counts are a fourth total-count domain** in the same family as frames, subframes and `Fraction` — and the one with the least headroom, since it overflows at ordinary limits rather than at a hypothetical future frame rate.

So this PR is gated on the consistency work discussed in #88, not on CI configuration. Once totals are `Int64`, adding the WASM test job here should be mechanical.

## Notes for whoever wires the job up

Four things that cost me time on my own WASM test lane:

1. `swift build --build-tests` has **no per-target form**, so it builds every test target including Apple-only ones. I narrow the manifest from an env var to the targets I want plus their transitive first-party deps.
2. SwiftPM's generated runner **defaults to XCTest**, whose wasi entry point reads `Bundle.main` and traps before running anything. Pass `--testing-library swift-testing`.
3. Run `--no-parallel` — a trap kills the process, and only serial execution makes "last test to start" the actual culprit.
4. **Give the module a real stack.** wasi-libc links a 64 KiB stack and wasm32 has no guard page, so overflow silently corrupts the heap and surfaces later, differently each run. It must go in the manifest, not the CLI: a CLI `-Xlinker -z -Xlinker stack-size=…` also reaches the host link of the macro plugins, and macOS `ld` rejects it.
