### PR TITLE
Diagnose Timeouts on GitHub CI macOS Runners 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   macOS:
     name: Tests (macOS)
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@main
@@ -45,7 +45,7 @@ jobs:
 
   macOS-swift6-2:
     name: Tests (macOS - Swift 6.2)
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@main
@@ -61,7 +61,7 @@ jobs:
 
   macCatalyst:
     name: Tests (macCatalyst)
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@main


### PR DESCRIPTION
CI jobs that test on macOS have been timing out for no reason whatsoever. I cannot reproduce locally.

The unusual aspect here is that the issue is fairly consistent in nature, and not random like most typical GitHub-hosted runner nonsense.